### PR TITLE
Make burnFrom() callable from non-bridge addresses

### DIFF
--- a/contracts/pegged/tokens/MultiBridgeToken.sol
+++ b/contracts/pegged/tokens/MultiBridgeToken.sol
@@ -51,7 +51,7 @@ contract MultiBridgeToken is ERC20, Ownable {
     }
 
     /**
-     * @notice Burns tokens from an address. Decreases total amount minted by the calling bridge.
+     * @notice Burns tokens from an address. Decreases total amount minted if called by a bridge.
      * Alternative to {burnFrom} for compatibility with some bridge implementations.
      * See {_burnFrom}.
      * @param _from The address to burn tokens from.
@@ -62,7 +62,7 @@ contract MultiBridgeToken is ERC20, Ownable {
     }
 
     /**
-     * @notice Burns tokens from an address. Decreases total amount minted by the calling bridge.
+     * @notice Burns tokens from an address. Decreases total amount minted if called by a bridge.
      * See {_burnFrom}.
      * @param _from The address to burn tokens from.
      * @param _amount The amount to burn.
@@ -72,16 +72,18 @@ contract MultiBridgeToken is ERC20, Ownable {
     }
 
     /**
-     * @dev Burns tokens from an address. Decreases total amount minted by the calling bridge.
+     * @dev Burns tokens from an address, deducting from the caller's allowance. Decreases total amount minted if called
+     * by a bridge.
      * @param _from The address to burn tokens from.
      * @param _amount The amount to burn.
      */
     function _burnFrom(address _from, uint256 _amount) internal returns (bool) {
         Supply storage b = bridges[msg.sender];
-        require(b.cap > 0, "invalid caller");
-        require(b.total >= _amount, "exceeds bridge minted amount");
-        unchecked {
-            b.total -= _amount;
+        if (b.cap > 0 || b.total > 0) {
+            require(b.total >= _amount, "exceeds bridge minted amount");
+            unchecked {
+                b.total -= _amount;
+            }
         }
         _spendAllowance(_from, msg.sender, _amount);
         _burn(_from, _amount);

--- a/contracts/pegged/tokens/SingleBridgeToken.sol
+++ b/contracts/pegged/tokens/SingleBridgeToken.sol
@@ -56,7 +56,7 @@ contract SingleBridgeToken is ERC20, Ownable {
      * @param _from The address to burn tokens from.
      * @param _amount The amount to burn.
      */
-    function burn(address _from, uint256 _amount) external onlyBridge returns (bool) {
+    function burn(address _from, uint256 _amount) external returns (bool) {
         return _burnFrom(_from, _amount);
     }
 
@@ -66,12 +66,12 @@ contract SingleBridgeToken is ERC20, Ownable {
      * @param _from The address to burn tokens from.
      * @param _amount The amount to burn.
      */
-    function burnFrom(address _from, uint256 _amount) external onlyBridge returns (bool) {
+    function burnFrom(address _from, uint256 _amount) external returns (bool) {
         return _burnFrom(_from, _amount);
     }
 
     /**
-     * @dev Burns tokens from an address.
+     * @dev Burns tokens from an address, deducting from the caller's allowance.
      * @param _from The address to burn tokens from.
      * @param _amount The amount to burn.
      */


### PR DESCRIPTION
This makes it compatible with OpenZeppelin's burnFrom() if called by
an address that is not a whitelisted bridge.