### PR TITLE
Use ">=0.8.0" for interfaces, part 2

### DIFF
--- a/contracts/message/framework/MessageBusAddress.sol
+++ b/contracts/message/framework/MessageBusAddress.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-pragma solidity 0.8.9;
+pragma solidity >=0.8.0;
 
 import "../../safeguard/Ownable.sol";
 

--- a/contracts/message/libraries/MsgDataTypes.sol
+++ b/contracts/message/libraries/MsgDataTypes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-pragma solidity 0.8.9;
+pragma solidity >=0.8.0;
 
 library MsgDataTypes {
     // bridge operation type at the sender side (src chain)


### PR DESCRIPTION
Follow up for

    commit e20c0697154760afd6fc2a0c9ab20e9d9adeb3a8
    Author: Michael Zhou <zhoumotongxue008@gmail.com>
    Date:   Tue Mar 22 12:44:40 2022 +0800

        Use ">=0.8.0" for interfaces

A few more items used by the interface contracts/interfaces had their
Solidity version fixed to 0.8.9.