### PR TITLE
enforce whitelist check on src chain. support multi-chain native NFT.

### DIFF
--- a/contracts/message/apps/NFTBridge.sol
+++ b/contracts/message/apps/NFTBridge.sol
@@ -122,6 +122,7 @@ contract NFTBridge is MessageReceiverApp {
         require(_dstNft != address(0), "dest NFT not found");
         address _dstBridge = destBridge[_dstChid];
         require(_dstBridge != address(0), "dest NFT Bridge not found");
+        require(msg.sender == INFT(_nft).ownerOf(_id), "not token owner");
         string memory _uri = INFT(_nft).tokenURI(_id);
         INFT(_nft).burn(_id);
         NFTMsg memory nftMsg = NFTMsg(MsgType.Mint, _receiver, _dstNft, _id, _uri);
@@ -188,6 +189,12 @@ contract NFTBridge is MessageReceiverApp {
     // set per chain id, nft bridge address
     function setDestBridge(uint64 dstChid, address dstNftBridge) external onlyOwner {
         destBridge[dstChid] = dstNftBridge;
+    }
+    // batch set nft bridge addresses for multiple chainids
+    function setDestBridges(uint64[] calldata dstChid, address[] calldata dstNftBridge) external onlyOwner {
+        for (uint i=0; i< dstChid.length; i++) {
+            destBridge[dstChid[i]] = dstNftBridge[i];
+        }
     }
     // send all gas token this contract has to owner
     function claimFee() external onlyOwner {

--- a/contracts/message/apps/NFTBridge.sol
+++ b/contracts/message/apps/NFTBridge.sol
@@ -18,7 +18,7 @@ interface INFT {
     ) external;
 
     // impl by NFToken contract, mint an NFT with id and uri to user or burn
-    function mint(
+    function bridgeMint(
         address to,
         uint256 id,
         string memory uri
@@ -160,7 +160,7 @@ contract NFTBridge is MessageReceiverApp {
         // withdraw original locked nft back to user, or mint new nft depending on msg.type
         NFTMsg memory nftMsg = abi.decode((_message), (NFTMsg));
         if (nftMsg.msgType == MsgType.Mint) {
-            INFT(nftMsg.nft).mint(nftMsg.user, nftMsg.id, nftMsg.uri);
+            INFT(nftMsg.nft).bridgeMint(nftMsg.user, nftMsg.id, nftMsg.uri);
         } else if (nftMsg.msgType == MsgType.Withdraw) {
             INFT(nftMsg.nft).transferFrom(address(this), nftMsg.user, nftMsg.id);
         } else {

--- a/contracts/message/apps/NFTMCN.sol
+++ b/contracts/message/apps/NFTMCN.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+
+interface INFTBridge {
+    function sendMsg(uint64 _dstChid, address _receiver, uint256 _id, string calldata _uri) external payable;
+    function totalFee(
+        uint64 _dstChid,
+        address _nft,
+        uint256 _id
+    ) external view returns (uint256);
+}
+
+// Multi-Chain Native NFT, same contract on all chains. User interacts with this directly.
+contract MCNNFT is ERC721URIStorage {
+    address public immutable nftBridge;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address _nftBridge
+    ) ERC721(name_, symbol_) {
+        nftBridge = _nftBridge;
+    }
+
+    modifier onlyNftBridge() {
+        require(msg.sender == nftBridge, "caller is not bridge");
+        _;
+    }
+
+    function mint(
+        address to,
+        uint256 id,
+        string memory uri
+    ) external onlyNftBridge {
+        _mint(to, id);
+        _setTokenURI(id, uri);
+    }
+
+    // calls nft bridge to get total fee for crossChain msg.Value
+    function totalFee(uint64 _dstChid, uint256 _id) external view returns (uint256) {
+        return INFTBridge(nftBridge).totalFee(_dstChid, address(this), _id);
+    }
+
+    // burn ID on this chain and mint on dest chain
+    function crossChain(uint64 _dstChid, uint256 _id, address _receiver) external payable {
+        string memory _uri = tokenURI(_id);
+        _burn(_id);
+        INFTBridge(nftBridge).sendMsg{value: msg.value}(_dstChid, _receiver, _id, _uri);
+    }
+}

--- a/contracts/message/apps/NFTMCN.sol
+++ b/contracts/message/apps/NFTMCN.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "../../safeguard/Ownable.sol";
 
 interface INFTBridge {
     function sendMsg(uint64 _dstChid, address _receiver, uint256 _id, string calldata _uri) external payable;
@@ -13,8 +14,9 @@ interface INFTBridge {
 }
 
 // Multi-Chain Native NFT, same contract on all chains. User interacts with this directly.
-contract MCNNFT is ERC721URIStorage {
-    address public immutable nftBridge;
+contract MCNNFT is ERC721URIStorage, Ownable {
+    event NFTBridgeUpdated(address);
+    address public nftBridge;
 
     constructor(
         string memory name_,
@@ -48,5 +50,11 @@ contract MCNNFT is ERC721URIStorage {
         string memory _uri = tokenURI(_id);
         _burn(_id);
         INFTBridge(nftBridge).sendMsg{value: msg.value}(_dstChid, _receiver, _id, _uri);
+    }
+
+    // only Owner
+    function setNFTBridge(address _newBridge) public onlyOwner {
+        nftBridge = _newBridge;
+        emit NFTBridgeUpdated(_newBridge);
     }
 }

--- a/contracts/message/apps/NFTMCN.sol
+++ b/contracts/message/apps/NFTMCN.sol
@@ -31,7 +31,7 @@ contract MCNNFT is ERC721URIStorage, Ownable {
         _;
     }
 
-    function mint(
+    function bridgeMint(
         address to,
         uint256 id,
         string memory uri

--- a/contracts/message/apps/NFTMCN.sol
+++ b/contracts/message/apps/NFTMCN.sol
@@ -47,6 +47,7 @@ contract MCNNFT is ERC721URIStorage, Ownable {
 
     // burn ID on this chain and mint on dest chain
     function crossChain(uint64 _dstChid, uint256 _id, address _receiver) external payable {
+        require(msg.sender == ownerOf(_id), "not token owner");
         string memory _uri = tokenURI(_id);
         _burn(_id);
         INFTBridge(nftBridge).sendMsg{value: msg.value}(_dstChid, _receiver, _id, _uri);

--- a/contracts/message/apps/NFTPeg.sol
+++ b/contracts/message/apps/NFTPeg.sol
@@ -19,7 +19,7 @@ contract PegNFT is ERC721URIStorage {
         _;
     }
 
-    function mint(
+    function bridgeMint(
         address to,
         uint256 id,
         string memory uri

--- a/deploy/message/apps/001_nft_bridge.ts
+++ b/deploy/message/apps/001_nft_bridge.ts
@@ -14,7 +14,20 @@ const deployFunc: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
     args: [
       process.env.MSG_BUS_ADDR
-    ]
+    ],
+    proxy: {
+      proxyContract: "OptimizedTransparentProxy",
+      execute: {
+        // only called when proxy is deployed, it'll call NFTBridge.init
+        // to set owner and msgbus in proxy contract state
+        init: {
+          methodName: 'init',
+          args: [
+            process.env.MSG_BUS_ADDR
+          ]
+        }
+      }
+    }
   });
 };
 

--- a/deploy/message/apps/004_nft_mcn.ts
+++ b/deploy/message/apps/004_nft_mcn.ts
@@ -1,0 +1,25 @@
+import * as dotenv from 'dotenv';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+dotenv.config();
+
+const deployFunc: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { deployments, getNamedAccounts } = hre;
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  await deploy('MCNNFT', {
+    from: deployer,
+    log: true,
+    args: [
+      process.env.NFT_NAME,
+      process.env.NFT_SYM,
+      process.env.NFT_BRIDGE_ADDR
+    ]
+  });
+};
+
+deployFunc.tags = ['MCNNFT'];
+deployFunc.dependencies = [];
+export default deployFunc;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,7 @@ import { HardhatUserConfig } from 'hardhat/types';
 dotenv.config();
 
 const DEFAULT_ENDPOINT = 'http://localhost:8545';
-const DEFAULT_PRIVATE_KEY = process.env.DEFAULT_PRIVATE_KEY;
+const DEFAULT_PRIVATE_KEY = process.env.DEFAULT_PRIVATE_KEY || 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
 // Testnets
 const kovanEndpoint = process.env.KOVAN_ENDPOINT || DEFAULT_ENDPOINT;


### PR DESCRIPTION
1. at cost of extra storage, enforce src nft must be whitelisted
2. support multi-chain native NFT. user only interacts with NFT contract, not nftbridge
3. dest chain nft bridge is stored in map and no longer needed in func args