### PR TITLE
Update transferId assignment logic in BridgeTransferLib

### DIFF
--- a/contracts/libraries/BridgeTransferLib.sol
+++ b/contracts/libraries/BridgeTransferLib.sol
@@ -364,18 +364,22 @@ library BridgeTransferLib {
     ) internal returns (ReceiveInfo memory) {
         ReceiveInfo memory recv;
         PbPegged.Withdraw memory request = PbPegged.decWithdraw(_request);
-        if (IOriginalTokenVaultV2(_bridgeAddr).records(request.refId)) {
-            recv.transferId = keccak256(
-                abi.encodePacked(
-                    request.receiver,
-                    request.token,
-                    request.amount,
-                    request.burnAccount,
-                    request.refChainId,
-                    request.refId,
-                    _bridgeAddr
-                )
-            );
+    
+        // Compute the exact withdrawId (wdId) used by OriginalTokenVaultV2
+        bytes32 wdId = keccak256(
+            abi.encodePacked(
+                request.receiver,
+                request.token,
+                request.amount,
+                request.burnAccount,
+                request.refChainId,
+                request.refId,
+                _bridgeAddr
+            )
+        );
+    
+        if (IOriginalTokenVaultV2(_bridgeAddr).records(wdId)) {
+            recv.transferId = wdId;
         } else {
             recv.transferId = IOriginalTokenVaultV2(_bridgeAddr).withdraw(_request, _sigs, _signers, _powers);
         }


### PR DESCRIPTION
Refactor withdrawId computation for consistency in transferId assignment by checking the correct wdId instead of request.refId